### PR TITLE
fix/docker bake - invalid CI and provenance

### DIFF
--- a/.github/workflows/backend-docker-build-push.yml
+++ b/.github/workflows/backend-docker-build-push.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/bake-action@v4
         env:
           BAKE_CI: true
-          HSAH: ${{ GITHUB_SHA:0:7 }}
+          HSAH: ${{ GITHUB_SHA }}
         with:
           target: backend
         # run: echo CI=true HSAH=${GITHUB_SHA:0:7} docker buildx bake backend

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,9 +18,12 @@ target "backend" {
   labels = {
     "org.opencontainers.image.source" = "https://github.com/htchan/WebHistory"
   }
+  attest = [
+    "type=provenance,disabled=true"
+  ]
 
   tags = [
-    "ghcr.io/htchan/web-history:${tgt}-v${DATE}-${HASH}",
+    "ghcr.io/htchan/web-history:${tgt}-v${DATE}-${substr(HASH,0,7)}",
     "ghcr.io/htchan/web-history:${tgt}-latest"
   ]
   platforms = equal(BAKE_CI, "true") ? ["linux/amd64","linux/arm64","linux/arm/v7"] : []


### PR DESCRIPTION
This PR disable provenance in docker buildx bake and update CI to provide full `HASH` by cropping hash within docker buildx bake