### PR TITLE
chore(logging): specific slog format for worker

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"os"
 	"syscall"
@@ -65,6 +66,8 @@ func main() {
 	}
 
 	zerolog.TimeFieldFormat = "2006-01-02T15:04:05.99999Z07:00"
+
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
 
 	conf, err := config.LoadWorkerConfig()
 	if err != nil {


### PR DESCRIPTION
This PR specific slog to use json format. 

# details 
This PR is using zerolog as primary logger. However, its dependency, [goworkers](https://github.com/htchan/goworkers) is using `slog` and it is not in json format. This PR is trying to solve this issue