### PR TITLE
chore: define the golang version in CI level to build docker image

### DIFF
--- a/.github/workflows/backend-docker-build-push.yml
+++ b/.github/workflows/backend-docker-build-push.yml
@@ -70,6 +70,7 @@ jobs:
           BRANCH: ${{ github.ref_name }}
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
+          GO_VERSION: ${{ env.GO_VERSION }}
         with:
           targets: ${{ matrix.target }}
           files: ./docker-bake.hcl

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.24.2-alpine AS builder
+ARG GO_VERSION
+
+FROM golang:${GO_VERSION}-alpine AS builder
 
 ARG SERVICE
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,6 +8,7 @@ variable "BAKE_CI" { default = "false" }
 
 variable "BRANCH" { default = "" }
 variable "IMAGE_TAG" { default = "${equal(BRANCH,"master") ? "latest" : "beta"}" }
+variable "GO_VERSION" { default = "1.24.2" }
 
 group "default" {
   targets = ["backend-api","backend-worker"]
@@ -28,6 +29,7 @@ target "backend" {
 
   args = {
     SERVICE = "${service}"
+    GO_VERSION = "${GO_VERSION}"
   }
 
   labels = {


### PR DESCRIPTION
This PR define the `GO_VERSION` in `dockerfile`, `docker-bake.hcl` and build push image github action to specify the golang version in github action level