### PR TITLE
Chore/client  update to goclient

### DIFF
--- a/.github/workflows/backend-docker-build-push.yml
+++ b/.github/workflows/backend-docker-build-push.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.24.6
+  GO_VERSION: 1.25.1
 
 jobs:
   Build-Push-Backend-Image:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -28,7 +28,7 @@ on:
       - '.github/workflows/backend-test.yml'
 
 env:
-  GO_VERSION: 1.24.6
+  GO_VERSION: 1.25.1
 
 jobs:
   Execute-Backend-Testcase:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 0 * * 6'
 
 env:
-  GO_VERSION: 1.24.6
+  GO_VERSION: 1.25.1
   TRIVY_VERSION: v0.61.1
 
 jobs:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,7 +8,7 @@ variable "BAKE_CI" { default = "false" }
 
 variable "BRANCH" { default = "" }
 variable "IMAGE_TAG" { default = "${equal(BRANCH,"master") ? "latest" : "beta"}" }
-variable "GO_VERSION" { default = "1.24.6" }
+variable "GO_VERSION" { default = "1.25.1" }
 
 group "default" {
   targets = ["backend-api","backend-worker"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/htchan/WebHistory
 
-go 1.24.6
+go 1.25.1
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0
@@ -9,12 +9,13 @@ require (
 	github.com/go-chi/cors v1.2.1
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/google/uuid v1.6.0
+	github.com/htchan/goclient v0.0.4
 	github.com/htchan/goshutdown v0.0.0-20231003015559-4aa563eafbb1
 	github.com/lib/pq v1.10.9
 	github.com/nats-io/nats.go v1.39.1
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/rs/zerolog v1.29.0
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/http-swagger/v2 v2.0.2
 	github.com/swaggo/swag v1.16.4
 	go.opentelemetry.io/otel v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -703,6 +703,8 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/htchan/goclient v0.0.4 h1:GL1swkFB846T9SrYHWTS784y6fUXdPDJC+bSXQXC78Q=
+github.com/htchan/goclient v0.0.4/go.mod h1:Ozmmi2HfeE1Z5JGleYdkdv3bbQxdH+g/TsyQ6LsSVsw=
 github.com/htchan/goshutdown v0.0.0-20231003015559-4aa563eafbb1 h1:4Ie8g+PJEgXG/sqkL/XkLmkShLMqIeRkQMIAkhytdIM=
 github.com/htchan/goshutdown v0.0.0-20231003015559-4aa563eafbb1/go.mod h1:cLXIumSEYq8s3dVicCVaRAnt6NKO46OzheaYIESjY/o=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
@@ -1162,8 +1164,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/swaggo/files/v2 v2.0.0 h1:hmAt8Dkynw7Ssz46F6pn8ok6YmGZqHSVLZ+HQM7i0kw=
 github.com/swaggo/files/v2 v2.0.0/go.mod h1:24kk2Y9NYEJ5lHuCra6iVwkMjIekMCaFq/0JQj66kyM=

--- a/internal/vendors/baozimh/vendor_service.go
+++ b/internal/vendors/baozimh/vendor_service.go
@@ -2,6 +2,7 @@ package baozimh
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,9 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -24,7 +28,7 @@ import (
 )
 
 type VendorService struct {
-	cli  *http.Client
+	cli  *goclient.Client
 	repo repository.Repostory
 	lock *semaphore.Weighted
 	cfg  *config.VendorServiceConfig
@@ -48,10 +52,19 @@ func getTracer() trace.Tracer {
 }
 
 func NewVendorService(
-	cli *http.Client,
 	repo repository.Repostory,
 	cfg *config.VendorServiceConfig,
 ) *VendorService {
+	cli := goclient.NewClient(
+		goclient.WithMiddlewares(
+			retry.NewRetryMiddleware(
+				cfg.MaxRetry,
+				retry.RetryForError,
+				retry.LinearRetryInterval(cfg.RetryInterval),
+			),
+			vendors.RaiseStatusCodeErrorMiddleware,
+		),
+	)
 	return &VendorService{
 		cli:  cli,
 		repo: repo,
@@ -84,28 +97,12 @@ func (serv *VendorService) fetchWebsite(ctx context.Context, web *model.Website)
 	var respErr error
 
 	// send request with basic retry
-	for i := 0; i < serv.cfg.MaxRetry; i++ {
-		resp, respErr = serv.cli.Do(req.WithContext(ctx))
-		defer func(resp *http.Response) {
-			if resp != nil {
-				resp.Body.Close()
-			}
-		}(resp)
-
-		if respErr == nil && (resp.StatusCode >= 200 && resp.StatusCode < 300) {
-			break
+	resp, respErr = serv.cli.Do(req.WithContext(ctx))
+	defer func(resp *http.Response) {
+		if resp != nil {
+			resp.Body.Close()
 		}
-
-		if respErr == nil {
-			if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
-				respErr = fmt.Errorf("fetch website failed: %w (%d)", vendors.ErrInvalidStatusCode, resp.StatusCode)
-			} else {
-				respErr = fmt.Errorf("fetch website failed: unknown error")
-			}
-		}
-
-		time.Sleep(time.Duration(i+1) * serv.cfg.RetryInterval)
-	}
+	}(resp)
 	if respErr != nil {
 		return "", respErr
 	}
@@ -171,8 +168,8 @@ func (serv *VendorService) isUpdated(ctx context.Context, web *model.Website, bo
 
 	if len(updateTimeStr) < 2 {
 		zerolog.Ctx(ctx).Warn().Str("update_time_str", doc.Find(dateGoQuery).Text()).Msg("cannot find update time str")
-		checkUpdateSpan.SetStatus(codes.Error, err.Error())
-		checkUpdateSpan.RecordError(err)
+		checkUpdateSpan.SetStatus(codes.Error, "cannot find update time str")
+		checkUpdateSpan.RecordError(errors.New("cannot find update time str"))
 
 		return isUpdated
 	}

--- a/internal/vendors/baozimh/vendor_service_test.go
+++ b/internal/vendors/baozimh/vendor_service_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/semaphore"
@@ -22,7 +24,6 @@ func TestNewVendorService(t *testing.T) {
 	t.Parallel()
 
 	type params struct {
-		cli  *http.Client
 		repo repository.Repostory
 		cfg  *config.VendorServiceConfig
 	}
@@ -35,7 +36,6 @@ func TestNewVendorService(t *testing.T) {
 		{
 			name: "happy flow",
 			params: params{
-				cli:  nil,
 				repo: nil,
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 10,
@@ -43,7 +43,6 @@ func TestNewVendorService(t *testing.T) {
 				},
 			},
 			want: &VendorService{
-				cli:  nil,
 				repo: nil,
 				lock: semaphore.NewWeighted(10),
 				cfg: &config.VendorServiceConfig{
@@ -59,8 +58,10 @@ func TestNewVendorService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			get := NewVendorService(tt.params.cli, tt.params.repo, tt.params.cfg)
-			assert.Equal(t, tt.want, get)
+			get := NewVendorService(tt.params.repo, tt.params.cfg)
+			assert.Equal(t, tt.want.repo, get.repo)
+			assert.Equal(t, tt.want.lock, get.lock)
+			assert.Equal(t, tt.want.cfg, get.cfg)
 		})
 	}
 }
@@ -95,7 +96,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request success",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -116,7 +126,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request failed",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							3,
+							retry.RetryForError,
+							retry.LinearRetryInterval(5*time.Millisecond),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -138,7 +157,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "cancelled context",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -393,7 +421,16 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "update web successfully",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -429,7 +466,16 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "fetch info but not update web",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -459,7 +505,16 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "repo returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -495,7 +550,16 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "send request returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -521,7 +585,16 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "context was cancelled",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,

--- a/internal/vendors/kuaikanmanhua/vendor_service.go
+++ b/internal/vendors/kuaikanmanhua/vendor_service.go
@@ -14,6 +14,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -23,7 +25,7 @@ import (
 )
 
 type VendorService struct {
-	cli  *http.Client
+	cli  *goclient.Client
 	repo repository.Repostory
 	lock *semaphore.Weighted
 	cfg  *config.VendorServiceConfig
@@ -49,7 +51,21 @@ func NewVendorService(
 	cfg *config.VendorServiceConfig,
 ) *VendorService {
 	return &VendorService{
-		cli:  cli,
+		cli: goclient.NewClient(
+			goclient.WithMiddlewares(
+				retry.NewRetryMiddleware(
+					cfg.MaxRetry,
+					retry.RetryForError,
+					retry.LinearRetryInterval(cfg.RetryInterval),
+				),
+				vendors.RaiseStatusCodeErrorMiddleware,
+			),
+			goclient.WithRequester(
+				func(req *http.Request) (*http.Response, error) {
+					return cli.Do(req)
+				},
+			),
+		),
 		repo: repo,
 		lock: semaphore.NewWeighted(cfg.MaxConcurrency),
 		cfg:  cfg,
@@ -76,32 +92,13 @@ func (serv *VendorService) fetchWebsite(ctx context.Context, web *model.Website)
 		return "", reqErr
 	}
 
-	var resp *http.Response
-	var respErr error
-
 	// send request with basic retry
-	for i := 0; i < serv.cfg.MaxRetry; i++ {
-		resp, respErr = serv.cli.Do(req.WithContext(ctx))
-		defer func(resp *http.Response) {
-			if resp != nil {
-				resp.Body.Close()
-			}
-		}(resp)
-
-		if respErr == nil && (resp.StatusCode >= 200 && resp.StatusCode < 300) {
-			break
+	resp, respErr := serv.cli.Do(req.WithContext(ctx))
+	defer func(resp *http.Response) {
+		if resp != nil {
+			resp.Body.Close()
 		}
-
-		if respErr == nil {
-			if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
-				respErr = fmt.Errorf("fetch website failed: %w (%d)", vendors.ErrInvalidStatusCode, resp.StatusCode)
-			} else {
-				respErr = fmt.Errorf("fetch website failed: unknown error")
-			}
-		}
-
-		time.Sleep(time.Duration(i+1) * serv.cfg.RetryInterval)
-	}
+	}(resp)
 	if respErr != nil {
 		return "", respErr
 	}

--- a/internal/vendors/kuaikanmanhua/vendor_service_test.go
+++ b/internal/vendors/kuaikanmanhua/vendor_service_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/semaphore"
@@ -60,7 +62,9 @@ func TestNewVendorService(t *testing.T) {
 			t.Parallel()
 
 			get := NewVendorService(tt.params.cli, tt.params.repo, tt.params.cfg)
-			assert.Equal(t, tt.want, get)
+			assert.Equal(t, tt.want.repo, get.repo)
+			assert.Equal(t, tt.want.lock, get.lock)
+			assert.Equal(t, tt.want.cfg, get.cfg)
 		})
 	}
 }
@@ -95,7 +99,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request success",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -116,7 +129,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request failed",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							3,
+							retry.RetryForError,
+							retry.LinearRetryInterval(5*time.Millisecond),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -138,7 +160,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "cancelled context",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -333,6 +364,16 @@ func TestVendorService_Update(t *testing.T) {
 	t.Parallel()
 
 	testError := fmt.Errorf("testing")
+	testClient := goclient.NewClient(
+		goclient.WithMiddlewares(
+			retry.NewRetryMiddleware(
+				1,
+				retry.RetryForError,
+				retry.StaticRetryInterval(0),
+			),
+			vendors.RaiseStatusCodeErrorMiddleware,
+		),
+	)
 
 	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/fail" {
@@ -370,7 +411,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "update web successfully",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -408,7 +449,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "fetch info but not update web",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -438,7 +479,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "repo returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -476,7 +517,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "send request returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -502,7 +543,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "context was cancelled",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,

--- a/internal/vendors/manhuagui/vendor_service.go
+++ b/internal/vendors/manhuagui/vendor_service.go
@@ -14,6 +14,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -23,7 +25,7 @@ import (
 )
 
 type VendorService struct {
-	cli  *http.Client
+	cli  *goclient.Client
 	repo repository.Repostory
 	lock *semaphore.Weighted
 	cfg  *config.VendorServiceConfig
@@ -51,7 +53,21 @@ func NewVendorService(
 	cfg *config.VendorServiceConfig,
 ) *VendorService {
 	return &VendorService{
-		cli:  cli,
+		cli: goclient.NewClient(
+			goclient.WithMiddlewares(
+				retry.NewRetryMiddleware(
+					cfg.MaxRetry,
+					retry.RetryForError,
+					retry.LinearRetryInterval(cfg.RetryInterval),
+				),
+				vendors.RaiseStatusCodeErrorMiddleware,
+			),
+			goclient.WithRequester(
+				func(req *http.Request) (*http.Response, error) {
+					return cli.Do(req)
+				},
+			),
+		),
 		repo: repo,
 		lock: semaphore.NewWeighted(cfg.MaxConcurrency),
 		cfg:  cfg,
@@ -78,32 +94,13 @@ func (serv *VendorService) fetchWebsite(ctx context.Context, web *model.Website)
 		return "", reqErr
 	}
 
-	var resp *http.Response
-	var respErr error
-
 	// send request with basic retry
-	for i := 0; i < serv.cfg.MaxRetry; i++ {
-		resp, respErr = serv.cli.Do(req.WithContext(ctx))
-		defer func(resp *http.Response) {
-			if resp != nil {
-				resp.Body.Close()
-			}
-		}(resp)
-
-		if respErr == nil && (resp.StatusCode >= 200 && resp.StatusCode < 300) {
-			break
+	resp, respErr := serv.cli.Do(req.WithContext(ctx))
+	defer func(resp *http.Response) {
+		if resp != nil {
+			resp.Body.Close()
 		}
-
-		if respErr == nil {
-			if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
-				respErr = fmt.Errorf("fetch website failed: %w (%d)", vendors.ErrInvalidStatusCode, resp.StatusCode)
-			} else {
-				respErr = fmt.Errorf("fetch website failed: unknown error")
-			}
-		}
-
-		time.Sleep(time.Duration(i+1) * serv.cfg.RetryInterval)
-	}
+	}(resp)
 	if respErr != nil {
 		return "", respErr
 	}

--- a/internal/vendors/manhuagui/vendor_service_test.go
+++ b/internal/vendors/manhuagui/vendor_service_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/semaphore"
@@ -60,7 +62,9 @@ func TestNewVendorService(t *testing.T) {
 			t.Parallel()
 
 			get := NewVendorService(tt.params.cli, tt.params.repo, tt.params.cfg)
-			assert.Equal(t, tt.want, get)
+			assert.Equal(t, tt.want.repo, get.repo)
+			assert.Equal(t, tt.want.lock, get.lock)
+			assert.Equal(t, tt.want.cfg, get.cfg)
 		})
 	}
 }
@@ -95,7 +99,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request success",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -116,7 +129,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request failed",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							3,
+							retry.RetryForError,
+							retry.LinearRetryInterval(5*time.Millisecond),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -138,7 +160,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "cancelled context",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -335,6 +366,16 @@ func TestVendorService_Update(t *testing.T) {
 	t.Parallel()
 
 	testError := fmt.Errorf("testing")
+	testClient := goclient.NewClient(
+		goclient.WithMiddlewares(
+			retry.NewRetryMiddleware(
+				1,
+				retry.RetryForError,
+				retry.StaticRetryInterval(0),
+			),
+			vendors.RaiseStatusCodeErrorMiddleware,
+		),
+	)
 
 	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/fail" {
@@ -364,7 +405,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "update web successfully",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -400,7 +441,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "fetch info but not update web",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -430,7 +471,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "repo returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -466,7 +507,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "send request returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -492,7 +533,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "context was cancelled",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,

--- a/internal/vendors/manhuaren/vendor_service.go
+++ b/internal/vendors/manhuaren/vendor_service.go
@@ -14,6 +14,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -23,7 +25,7 @@ import (
 )
 
 type VendorService struct {
-	cli  *http.Client
+	cli  *goclient.Client
 	repo repository.Repostory
 	lock *semaphore.Weighted
 	cfg  *config.VendorServiceConfig
@@ -52,7 +54,21 @@ func NewVendorService(
 	cfg *config.VendorServiceConfig,
 ) *VendorService {
 	return &VendorService{
-		cli:  cli,
+		cli: goclient.NewClient(
+			goclient.WithMiddlewares(
+				retry.NewRetryMiddleware(
+					cfg.MaxRetry,
+					retry.RetryForError,
+					retry.LinearRetryInterval(cfg.RetryInterval),
+				),
+				vendors.RaiseStatusCodeErrorMiddleware,
+			),
+			goclient.WithRequester(
+				func(req *http.Request) (*http.Response, error) {
+					return cli.Do(req)
+				},
+			),
+		),
 		repo: repo,
 		lock: semaphore.NewWeighted(cfg.MaxConcurrency),
 		cfg:  cfg,
@@ -79,32 +95,13 @@ func (serv *VendorService) fetchWebsite(ctx context.Context, web *model.Website)
 		return "", reqErr
 	}
 
-	var resp *http.Response
-	var respErr error
-
 	// send request with basic retry
-	for i := 0; i < serv.cfg.MaxRetry; i++ {
-		resp, respErr = serv.cli.Do(req.WithContext(ctx))
-		defer func(resp *http.Response) {
-			if resp != nil {
-				resp.Body.Close()
-			}
-		}(resp)
-
-		if respErr == nil && (resp.StatusCode >= 200 && resp.StatusCode < 300) {
-			break
+	resp, respErr := serv.cli.Do(req.WithContext(ctx))
+	defer func(resp *http.Response) {
+		if resp != nil {
+			resp.Body.Close()
 		}
-
-		if respErr == nil {
-			if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
-				respErr = fmt.Errorf("fetch website failed: %w (%d)", vendors.ErrInvalidStatusCode, resp.StatusCode)
-			} else {
-				respErr = fmt.Errorf("fetch website failed: unknown error")
-			}
-		}
-
-		time.Sleep(time.Duration(i+1) * serv.cfg.RetryInterval)
-	}
+	}(resp)
 	if respErr != nil {
 		return "", respErr
 	}

--- a/internal/vendors/qiman6/vendor_service.go
+++ b/internal/vendors/qiman6/vendor_service.go
@@ -14,6 +14,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -23,7 +25,7 @@ import (
 )
 
 type VendorService struct {
-	cli  *http.Client
+	cli  *goclient.Client
 	repo repository.Repostory
 	lock *semaphore.Weighted
 	cfg  *config.VendorServiceConfig
@@ -49,7 +51,21 @@ func NewVendorService(
 	cfg *config.VendorServiceConfig,
 ) *VendorService {
 	return &VendorService{
-		cli:  cli,
+		cli: goclient.NewClient(
+			goclient.WithMiddlewares(
+				retry.NewRetryMiddleware(
+					cfg.MaxRetry,
+					retry.RetryForError,
+					retry.LinearRetryInterval(cfg.RetryInterval),
+				),
+				vendors.RaiseStatusCodeErrorMiddleware,
+			),
+			goclient.WithRequester(
+				func(req *http.Request) (*http.Response, error) {
+					return cli.Do(req)
+				},
+			),
+		),
 		repo: repo,
 		lock: semaphore.NewWeighted(cfg.MaxConcurrency),
 		cfg:  cfg,
@@ -76,32 +92,13 @@ func (serv *VendorService) fetchWebsite(ctx context.Context, web *model.Website)
 		return "", reqErr
 	}
 
-	var resp *http.Response
-	var respErr error
-
 	// send request with basic retry
-	for i := 0; i < serv.cfg.MaxRetry; i++ {
-		resp, respErr = serv.cli.Do(req.WithContext(ctx))
-		defer func(resp *http.Response) {
-			if resp != nil {
-				resp.Body.Close()
-			}
-		}(resp)
-
-		if respErr == nil && (resp.StatusCode >= 200 && resp.StatusCode < 300) {
-			break
+	resp, respErr := serv.cli.Do(req.WithContext(ctx))
+	defer func(resp *http.Response) {
+		if resp != nil {
+			resp.Body.Close()
 		}
-
-		if respErr == nil {
-			if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
-				respErr = fmt.Errorf("fetch website failed: %w (%d)", vendors.ErrInvalidStatusCode, resp.StatusCode)
-			} else {
-				respErr = fmt.Errorf("fetch website failed: unknown error")
-			}
-		}
-
-		time.Sleep(time.Duration(i+1) * serv.cfg.RetryInterval)
-	}
+	}(resp)
 	if respErr != nil {
 		return "", respErr
 	}

--- a/internal/vendors/qiman6/vendor_service_test.go
+++ b/internal/vendors/qiman6/vendor_service_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/semaphore"
@@ -60,7 +62,9 @@ func TestNewVendorService(t *testing.T) {
 			t.Parallel()
 
 			get := NewVendorService(tt.params.cli, tt.params.repo, tt.params.cfg)
-			assert.Equal(t, tt.want, get)
+			assert.Equal(t, tt.want.repo, get.repo)
+			assert.Equal(t, tt.want.lock, get.lock)
+			assert.Equal(t, tt.want.cfg, get.cfg)
 		})
 	}
 }
@@ -95,7 +99,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request success",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -116,7 +129,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request failed",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							3,
+							retry.RetryForError,
+							retry.LinearRetryInterval(5*time.Millisecond),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -138,7 +160,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "cancelled context",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -321,6 +352,16 @@ func TestVendorService_Update(t *testing.T) {
 	t.Parallel()
 
 	testError := fmt.Errorf("testing")
+	testClient := goclient.NewClient(
+		goclient.WithMiddlewares(
+			retry.NewRetryMiddleware(
+				1,
+				retry.RetryForError,
+				retry.StaticRetryInterval(0),
+			),
+			vendors.RaiseStatusCodeErrorMiddleware,
+		),
+	)
 
 	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/fail" {
@@ -352,7 +393,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "update web successfully",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -390,7 +431,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "fetch info but not update web",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -420,7 +461,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "repo returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -458,7 +499,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "send request returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -484,7 +525,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "context was cancelled",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,

--- a/internal/vendors/u17/vendor_service.go
+++ b/internal/vendors/u17/vendor_service.go
@@ -14,6 +14,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -23,7 +25,7 @@ import (
 )
 
 type VendorService struct {
-	cli  *http.Client
+	cli  *goclient.Client
 	repo repository.Repostory
 	lock *semaphore.Weighted
 	cfg  *config.VendorServiceConfig
@@ -49,7 +51,21 @@ func NewVendorService(
 	cfg *config.VendorServiceConfig,
 ) *VendorService {
 	return &VendorService{
-		cli:  cli,
+		cli: goclient.NewClient(
+			goclient.WithMiddlewares(
+				retry.NewRetryMiddleware(
+					cfg.MaxRetry,
+					retry.RetryForError,
+					retry.LinearRetryInterval(cfg.RetryInterval),
+				),
+				vendors.RaiseStatusCodeErrorMiddleware,
+			),
+			goclient.WithRequester(
+				func(req *http.Request) (*http.Response, error) {
+					return cli.Do(req)
+				},
+			),
+		),
 		repo: repo,
 		lock: semaphore.NewWeighted(cfg.MaxConcurrency),
 		cfg:  cfg,
@@ -76,32 +92,13 @@ func (serv *VendorService) fetchWebsite(ctx context.Context, web *model.Website)
 		return "", reqErr
 	}
 
-	var resp *http.Response
-	var respErr error
-
 	// send request with basic retry
-	for i := 0; i < serv.cfg.MaxRetry; i++ {
-		resp, respErr = serv.cli.Do(req.WithContext(ctx))
-		defer func(resp *http.Response) {
-			if resp != nil {
-				resp.Body.Close()
-			}
-		}(resp)
-
-		if respErr == nil && (resp.StatusCode >= 200 && resp.StatusCode < 300) {
-			break
+	resp, respErr := serv.cli.Do(req.WithContext(ctx))
+	defer func(resp *http.Response) {
+		if resp != nil {
+			resp.Body.Close()
 		}
-
-		if respErr == nil {
-			if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
-				respErr = fmt.Errorf("fetch website failed: %w (%d)", vendors.ErrInvalidStatusCode, resp.StatusCode)
-			} else {
-				respErr = fmt.Errorf("fetch website failed: unknown error")
-			}
-		}
-
-		time.Sleep(time.Duration(i+1) * serv.cfg.RetryInterval)
-	}
+	}(resp)
 	if respErr != nil {
 		return "", respErr
 	}

--- a/internal/vendors/u17/vendor_service_test.go
+++ b/internal/vendors/u17/vendor_service_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/semaphore"
@@ -60,7 +62,9 @@ func TestNewVendorService(t *testing.T) {
 			t.Parallel()
 
 			get := NewVendorService(tt.params.cli, tt.params.repo, tt.params.cfg)
-			assert.Equal(t, tt.want, get)
+			assert.Equal(t, tt.want.repo, get.repo)
+			assert.Equal(t, tt.want.lock, get.lock)
+			assert.Equal(t, tt.want.cfg, get.cfg)
 		})
 	}
 }
@@ -95,7 +99,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request success",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -116,7 +129,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request failed",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							3,
+							retry.RetryForError,
+							retry.LinearRetryInterval(5*time.Millisecond),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -138,7 +160,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "cancelled context",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -325,6 +356,16 @@ func TestVendorService_Update(t *testing.T) {
 	t.Parallel()
 
 	testError := fmt.Errorf("testing")
+	testClient := goclient.NewClient(
+		goclient.WithMiddlewares(
+			retry.NewRetryMiddleware(
+				1,
+				retry.RetryForError,
+				retry.StaticRetryInterval(0),
+			),
+			vendors.RaiseStatusCodeErrorMiddleware,
+		),
+	)
 
 	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/fail" {
@@ -358,7 +399,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "update web successfully",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -396,7 +437,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "fetch info but not update web",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -426,7 +467,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "repo returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -464,7 +505,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "send request returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -490,7 +531,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "context was cancelled",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,

--- a/internal/vendors/vendor_service.go
+++ b/internal/vendors/vendor_service.go
@@ -3,8 +3,10 @@ package vendors
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/htchan/WebHistory/internal/model"
+	"github.com/htchan/goclient"
 )
 
 var ErrInvalidStatusCode = fmt.Errorf("invalid status code")
@@ -16,4 +18,15 @@ type VendorService interface {
 	Update(context.Context, *model.Website) error
 	Name() string
 	// Download(context.Context, *model.Website) error
+}
+
+func RaiseStatusCodeErrorMiddleware(f goclient.Requester) goclient.Requester {
+	return func(req *http.Request) (*http.Response, error) {
+		resp, err := f(req)
+		if err != nil || (resp.StatusCode >= 200 && resp.StatusCode < 300) {
+			return resp, err
+		}
+
+		return resp, fmt.Errorf("fetch website failed: %w (%d)", ErrInvalidStatusCode, resp.StatusCode)
+	}
 }

--- a/internal/vendors/webtoons/vendor_service.go
+++ b/internal/vendors/webtoons/vendor_service.go
@@ -14,6 +14,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -23,7 +25,7 @@ import (
 )
 
 type VendorService struct {
-	cli  *http.Client
+	cli  *goclient.Client
 	repo repository.Repostory
 	lock *semaphore.Weighted
 	cfg  *config.VendorServiceConfig
@@ -51,7 +53,21 @@ func NewVendorService(
 	cfg *config.VendorServiceConfig,
 ) *VendorService {
 	return &VendorService{
-		cli:  cli,
+		cli: goclient.NewClient(
+			goclient.WithMiddlewares(
+				retry.NewRetryMiddleware(
+					cfg.MaxRetry,
+					retry.RetryForError,
+					retry.LinearRetryInterval(cfg.RetryInterval),
+				),
+				vendors.RaiseStatusCodeErrorMiddleware,
+			),
+			goclient.WithRequester(
+				func(req *http.Request) (*http.Response, error) {
+					return cli.Do(req)
+				},
+			),
+		),
 		repo: repo,
 		lock: semaphore.NewWeighted(cfg.MaxConcurrency),
 		cfg:  cfg,
@@ -78,32 +94,13 @@ func (serv *VendorService) fetchWebsite(ctx context.Context, web *model.Website)
 		return "", reqErr
 	}
 
-	var resp *http.Response
-	var respErr error
-
 	// send request with basic retry
-	for i := 0; i < serv.cfg.MaxRetry; i++ {
-		resp, respErr = serv.cli.Do(req.WithContext(ctx))
-		defer func(resp *http.Response) {
-			if resp != nil {
-				resp.Body.Close()
-			}
-		}(resp)
-
-		if respErr == nil && (resp.StatusCode >= 200 && resp.StatusCode < 300) {
-			break
+	resp, respErr := serv.cli.Do(req.WithContext(ctx))
+	defer func(resp *http.Response) {
+		if resp != nil {
+			resp.Body.Close()
 		}
-
-		if respErr == nil {
-			if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
-				respErr = fmt.Errorf("fetch website failed: %w (%d)", vendors.ErrInvalidStatusCode, resp.StatusCode)
-			} else {
-				respErr = fmt.Errorf("fetch website failed: unknown error")
-			}
-		}
-
-		time.Sleep(time.Duration(i+1) * serv.cfg.RetryInterval)
-	}
+	}(resp)
 	if respErr != nil {
 		return "", respErr
 	}

--- a/internal/vendors/webtoons/vendor_service_test.go
+++ b/internal/vendors/webtoons/vendor_service_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/htchan/WebHistory/internal/model"
 	"github.com/htchan/WebHistory/internal/repository"
 	"github.com/htchan/WebHistory/internal/vendors"
+	"github.com/htchan/goclient"
+	"github.com/htchan/goclient/middlewares/retry"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/semaphore"
@@ -60,7 +62,9 @@ func TestNewVendorService(t *testing.T) {
 			t.Parallel()
 
 			get := NewVendorService(tt.params.cli, tt.params.repo, tt.params.cfg)
-			assert.Equal(t, tt.want, get)
+			assert.Equal(t, tt.want.repo, get.repo)
+			assert.Equal(t, tt.want.lock, get.lock)
+			assert.Equal(t, tt.want.cfg, get.cfg)
 		})
 	}
 }
@@ -95,7 +99,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request success",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -116,7 +129,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "send request failed",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							3,
+							retry.RetryForError,
+							retry.LinearRetryInterval(5*time.Millisecond),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -138,7 +160,16 @@ func TestVendorService_fetchWebsite(t *testing.T) {
 		{
 			name: "cancelled context",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli: goclient.NewClient(
+					goclient.WithMiddlewares(
+						retry.NewRetryMiddleware(
+							1,
+							retry.RetryForError,
+							retry.StaticRetryInterval(0),
+						),
+						vendors.RaiseStatusCodeErrorMiddleware,
+					),
+				),
 				repo: nil,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
@@ -345,6 +376,16 @@ func TestVendorService_Update(t *testing.T) {
 	t.Parallel()
 
 	testError := fmt.Errorf("testing")
+	testClient := goclient.NewClient(
+		goclient.WithMiddlewares(
+			retry.NewRetryMiddleware(
+				1,
+				retry.RetryForError,
+				retry.StaticRetryInterval(0),
+			),
+			vendors.RaiseStatusCodeErrorMiddleware,
+		),
+	)
 
 	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/fail" {
@@ -376,7 +417,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "update web successfully",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -412,7 +453,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "fetch info but not update web",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -442,7 +483,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "repo returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -478,7 +519,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "send request returning error",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,
@@ -504,7 +545,7 @@ func TestVendorService_Update(t *testing.T) {
 		{
 			name: "context was cancelled",
 			serv: &VendorService{
-				cli:  http.DefaultClient,
+				cli:  testClient,
 				lock: semaphore.NewWeighted(1),
 				cfg: &config.VendorServiceConfig{
 					MaxConcurrency: 1,


### PR DESCRIPTION
This Pr updates the `http.Client` used in `vendor` package to be `goclient.Client` which support middlewares 