### PR TITLE
Chore/add status to website

### DIFF
--- a/database/migrations/20251026024656_add-status-to-websites-table.down.sql
+++ b/database/migrations/20251026024656_add-status-to-websites-table.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX idx_websites_status;
+
+ALTER TABLE websites DROP COLUMN status;

--- a/database/migrations/20251026024656_add-status-to-websites-table.up.sql
+++ b/database/migrations/20251026024656_add-status-to-websites-table.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE websites ADD status TEXT DEFAULT 'active' NOT NULL;
+
+CREATE INDEX idx_websites_status ON websites(status);

--- a/database/sqlc/queries.sql
+++ b/database/sqlc/queries.sql
@@ -16,11 +16,11 @@ RETURNING *;
 -- name: DeleteWebsite :exec
 DELETE FROM websites WHERE uuid=$1;
 
--- name: ListWebsites :many
-SELECT * FROM websites;
+-- name: ListActiveWebsites :many
+SELECT * FROM websites WHERE status='active';
 
 -- name: GetWebsite :one
-SELECT * from websites WHERE uuid=$1;
+SELECT * from websites WHERE uuid=$1 and status != 'inactive';
 
 -- name: CreateUserWebsite :one
 INSERT INTO user_websites
@@ -45,17 +45,17 @@ where user_uuid=$1 and website_uuid=$2;
 SELECT website_uuid, user_uuid, access_time, group_name,
 uuid, url, title, update_time 
 FROM user_websites JOIN websites ON user_websites.website_uuid=websites.uuid 
-WHERE user_uuid=$1
+WHERE user_uuid=$1 and websites.status != 'inactive'
 ORDER BY (update_time > access_time) DESC, update_time DESC, access_time DESC;
 
 -- name: ListUserWebsitesByGroup :many
 SELECT website_uuid, user_uuid, access_time, group_name ,
 uuid, url, title, update_time 
 FROM user_websites JOIN websites ON user_websites.website_uuid=websites.uuid 
-WHERE user_uuid=$1 and group_name=$2;
+WHERE user_uuid=$1 and group_name=$2 and websites.status != 'inactive';
 
 -- name: GetUserWebsite :one
 SELECT website_uuid, user_uuid, access_time, group_name ,
 uuid, url, title, update_time 
 FROM user_websites JOIN websites ON user_websites.website_uuid=websites.uuid 
-WHERE user_uuid=$1 and website_uuid=$2;
+WHERE user_uuid=$1 and website_uuid=$2 and websites.status != 'inactive';

--- a/database/sqlc/schema.sql
+++ b/database/sqlc/schema.sql
@@ -44,11 +44,19 @@ CREATE TABLE public.websites (
     url text,
     title text,
     content text,
-    update_time timestamp without time zone
+    update_time timestamp without time zone,
+    status text DEFAULT 'active'::text NOT NULL
 );
 
 
 ALTER TABLE public.websites OWNER TO web_history;
+
+--
+-- Name: idx_websites_status; Type: INDEX; Schema: public; Owner: web_history
+--
+
+CREATE INDEX idx_websites_status ON public.websites USING btree (status);
+
 
 --
 -- Name: user_websites__user_and_uuid; Type: INDEX; Schema: public; Owner: web_history

--- a/internal/model/website.go
+++ b/internal/model/website.go
@@ -16,6 +16,7 @@ type Website struct {
 	Title      string                `json:"title"`
 	RawContent string                `json:"raw_content"`
 	UpdateTime time.Time             `json:"update_time"`
+	Status     string                `json:"-"`
 	Conf       *config.WebsiteConfig `json:"-"`
 }
 

--- a/internal/repository/sqlc/sqlc_repo.go
+++ b/internal/repository/sqlc/sqlc_repo.go
@@ -48,6 +48,7 @@ func fromSqlcWebsite(webModel sqlc.Website) model.Website {
 		Title:      webModel.Title.String,
 		RawContent: webModel.Content.String,
 		UpdateTime: webModel.UpdateTime.Time.UTC().Truncate(MinTimeUnit),
+		Status:     webModel.Status,
 	}
 }
 
@@ -226,7 +227,7 @@ func (r *SqlcRepo) FindWebsites(ctx context.Context) ([]model.Website, error) {
 	_, listWebsitesSpan := repository.GetTracer().Start(ctx, "find websites")
 	defer listWebsitesSpan.End()
 
-	webModels, err := r.db.ListWebsites(ctx)
+	webModels, err := r.db.ListActiveWebsites(ctx)
 	if err != nil {
 		listWebsitesSpan.SetStatus(codes.Error, err.Error())
 		listWebsitesSpan.RecordError(err)

--- a/internal/repository/sqlc/sqlc_repo_benchmark_test.go
+++ b/internal/repository/sqlc/sqlc_repo_benchmark_test.go
@@ -55,7 +55,7 @@ func BenchmarkPsqlRepo_UpdateWebsite(b *testing.B) {
 	title := "benchmark-update-website"
 	uuid := "benchmark-update-website-uuid"
 	userUUID := "benchmark-update-website-user-uuid"
-	populateData(db, uuid, title, userUUID)
+	populateData(db, uuid, title, userUUID, "active")
 
 	r := NewRepo(db, &config.WebsiteConfig{})
 	b.Cleanup(func() {
@@ -105,7 +105,7 @@ func BenchmarkPsqlRepo_DeleteWebsite(b *testing.B) {
 	b.ResetTimer()
 	b.StopTimer()
 	for n := 0; n < b.N; n++ {
-		populateData(db, uuid, title, userUUID)
+		populateData(db, uuid, title, userUUID, "active")
 		b.StartTimer()
 		err := r.DeleteWebsite(context.Background(), &model.Website{UUID: uuid})
 		b.StopTimer()
@@ -124,7 +124,7 @@ func BenchmarkPsqlRepo_FindWebsites(b *testing.B) {
 	title := "benchmark-find-websites"
 	uuid := "benchmark-find-websites-uuid"
 	userUUID := "benchmark-find-websites-user-uuid"
-	populateData(db, uuid, title, userUUID)
+	populateData(db, uuid, title, userUUID, "active")
 
 	r := NewRepo(db, &config.WebsiteConfig{})
 	b.Cleanup(func() {
@@ -154,7 +154,7 @@ func BenchmarkPsqlRepo_FindWebsite(b *testing.B) {
 	title := "benchmark-find-website"
 	uuid := "benchmark-find-website-uuid"
 	userUUID := "benchmark-find-website-user-uuid"
-	populateData(db, uuid, title, userUUID)
+	populateData(db, uuid, title, userUUID, "active")
 
 	r := NewRepo(db, &config.WebsiteConfig{})
 	b.Cleanup(func() {
@@ -184,7 +184,7 @@ func BenchmarkPsqlRepo_CreateUserWebsite(b *testing.B) {
 	uuid := "benchmark-create-user-website-uuid"
 	title := "benchmark create user website"
 	userUUID := "benchmark-create-user-website-user-uuid"
-	populateData(db, uuid, title, userUUID)
+	populateData(db, uuid, title, userUUID, "active")
 
 	r := NewRepo(db, &config.WebsiteConfig{})
 	b.Cleanup(func() {
@@ -222,7 +222,7 @@ func BenchmarkPsqlRepo_UpdateUserWebsite(b *testing.B) {
 	title := "benchmark-update-user-website"
 	userUUID := "benchmark-update-user-website-user-uuid"
 	uuid := "benchmark-update-user-website-uuid"
-	populateData(db, uuid, title, userUUID)
+	populateData(db, uuid, title, userUUID, "active")
 
 	r := NewRepo(db, &config.WebsiteConfig{})
 	b.Cleanup(func() {
@@ -271,7 +271,7 @@ func BenchmarkPsqlRepo_DeleteUserWebsite(b *testing.B) {
 	b.ResetTimer()
 	b.StopTimer()
 	for n := 0; n < b.N; n++ {
-		populateData(db, uuid, title, userUUID)
+		populateData(db, uuid, title, userUUID, "active")
 		b.StartTimer()
 		err := r.DeleteUserWebsite(context.Background(), &model.UserWebsite{WebsiteUUID: uuid, UserUUID: userUUID})
 		b.StopTimer()
@@ -290,7 +290,7 @@ func BenchmarkPsqlRepo_FindUserWebsites(b *testing.B) {
 	title := "benchmark-find-user-websites"
 	uuid := "benchmark-find-user-websites-uuid"
 	userUUID := "benchmark-find-user-websites-user-uuid"
-	populateData(db, uuid, title, userUUID)
+	populateData(db, uuid, title, userUUID, "active")
 
 	r := NewRepo(db, &config.WebsiteConfig{})
 	b.Cleanup(func() {
@@ -320,7 +320,7 @@ func BenchmarkPsqlRepo_FindUserWebsitesByGroup(b *testing.B) {
 	title := "benchmark-find-user-websites-by-group"
 	uuid := "benchmark-find-user-websites-by-group-uuid"
 	userUUID := "benchmark-find-user-websites-by-group-user-uuid"
-	populateData(db, uuid, title, userUUID)
+	populateData(db, uuid, title, userUUID, "active")
 
 	r := NewRepo(db, &config.WebsiteConfig{})
 	b.Cleanup(func() {
@@ -350,7 +350,7 @@ func BenchmarkPsqlRepo_FindUserWebsite(b *testing.B) {
 	title := "benchmark-find-user-website"
 	uuid := "benchmark-find-user-website-uuid"
 	userUUID := "benchmark-find-user-website-user-uuid"
-	populateData(db, uuid, title, userUUID)
+	populateData(db, uuid, title, userUUID, "active")
 
 	r := NewRepo(db, &config.WebsiteConfig{})
 	b.Cleanup(func() {

--- a/internal/repository/sqlc/sqlc_test.go
+++ b/internal/repository/sqlc/sqlc_test.go
@@ -123,11 +123,12 @@ func setupContainer() (string, func(), error) {
 	return connString, purge, nil
 }
 
-func populateData(db *sql.DB, uuid, title, userUUID string) error {
-	_, err := db.Exec("insert into websites (uuid, url, title, content, update_time) values ($1, $2, $3, 'content', $4)", uuid, "http://example.com/"+title, title, time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC))
+func populateData(db *sql.DB, uuid, title, userUUID, status string) error {
+	_, err := db.Exec("insert into websites (uuid, url, title, content, update_time, status) values ($1, $2, $3, 'content', $4, $5)", uuid, "http://example.com/"+title, title, time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC), status)
 	if err != nil {
 		return err
 	}
+
 	_, err = db.Exec("insert into user_websites (website_uuid, user_uuid, group_name, access_time) values ($1, $2, $3, $4)", uuid, userUUID, title, time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC))
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -21,4 +21,5 @@ type Website struct {
 	Title      sql.NullString
 	Content    sql.NullString
 	UpdateTime sql.NullTime
+	Status     string
 }


### PR DESCRIPTION
This PR adds `status` column to `websites` table. so update website job will only handle websites with `active` status API will only return `active` and `read_only` status. Websites with `inactive` status will be ignored.