### PR TITLE
fix(security): upgrade Go version from 1.26.4 to 1.26.5 to address GO-2026-5856 vulnerability

### DIFF
--- a/.github/workflows/backend-docker-build-push.yml
+++ b/.github/workflows/backend-docker-build-push.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   Build-Push-Backend-Image:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -28,7 +28,7 @@ on:
       - ".github/workflows/backend-test.yml"
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   Execute-Backend-Testcase:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,7 +11,7 @@ on:
     - cron: "0 0 * * 6"
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   security-scan:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,7 +8,7 @@ variable "BAKE_CI" { default = "false" }
 
 variable "BRANCH" { default = "" }
 variable "IMAGE_TAG" { default = "${equal(BRANCH,"master") ? "latest" : "beta"}" }
-variable "GO_VERSION" { default = "1.26.4" }
+variable "GO_VERSION" { default = "1.26.5" }
 
 group "default" {
   targets = ["backend-api","backend-worker"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/htchan/WebHistory
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0


### PR DESCRIPTION
Fix for GO-2026-5856 Encrypted Client Hello privacy leak. Upgrading Go from 1.26.4 to 1.26.5.