### PR TITLE
fix(security): upgrade Go version from 1.26.5 to 1.26.6 to fix GO-2026-6218, GO-2026-6091, GO-2026-6090, GO-2026-6089, GO-2026-5972, GO-2026-5026 vulnerabilities

### DIFF
--- a/.github/workflows/backend-docker-build-push.yml
+++ b/.github/workflows/backend-docker-build-push.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
 
 jobs:
   Build-Push-Backend-Image:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -28,7 +28,7 @@ on:
       - ".github/workflows/backend-test.yml"
 
 env:
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
 
 jobs:
   Execute-Backend-Testcase:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,7 +11,7 @@ on:
     - cron: "0 0 * * 6"
 
 env:
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
 
 jobs:
   security-scan:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,7 +8,7 @@ variable "BAKE_CI" { default = "false" }
 
 variable "BRANCH" { default = "" }
 variable "IMAGE_TAG" { default = "${equal(BRANCH,"master") ? "latest" : "beta"}" }
-variable "GO_VERSION" { default = "1.26.5" }
+variable "GO_VERSION" { default = "1.26.6" }
 
 group "default" {
   targets = ["backend-api","backend-worker"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/htchan/WebHistory
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0


### PR DESCRIPTION
This PR fixes 6 Go standard library vulnerabilities by upgrading the Go version from 1.26.5 to 1.26.6.

Vulnerabilities addressed:
- GO-2026-6218: Avoid quadratic complexity in resolvePath in net/url
- GO-2026-6091: Fix Javascript regexp context tracking in html/template
- GO-2026-6090: Limit handshake messages we are willing to accept post-handshake in crypto/tls
- GO-2026-6089: Apply ReadHeaderTimeout when doing unencrypted HTTP/2 check in net/http
- GO-2026-5972: Enforce maximum recursion depth in encoding/asn1
- GO-2026-5026: Invoking failure to reject ASCII-only Punycode-encoded labels in golang.org/x/net/idna

Changes made:
- go.mod: Updated go directive from 1.26.5 to 1.26.6
- docker-bake.hcl: Updated GO_VERSION variable from 1.26.5 to 1.26.6
- .github/workflows/backend-test.yml: Updated GO_VERSION from 1.26.5 to 1.26.6
- .github/workflows/security-scan.yml: Updated GO_VERSION from 1.26.5 to 1.26.6
- .github/workflows/backend-docker-build-push.yml: Updated GO_VERSION from 1.26.5 to 1.26.6

All updates are consistent across the codebase to ensure proper Go version usage.